### PR TITLE
Transformar campo de título do post em uma textarea

### DIFF
--- a/orbita.php
+++ b/orbita.php
@@ -480,7 +480,7 @@ function orbita_form_shortcode() {
 	$html .= '      <input type="hidden" name="orbita_nonce" value="' . wp_create_nonce( 'orbita_nonce' ) . '">';
 	$html .= '      <div class="orbita-form-control">';
 	$html .= '          <label for="orbita_post_title">Título</label>';
-	$html .= '          <input required type="text" id="orbita_post_title" name="orbita_post_title" value="' . $get_t . '" placeholder="Prefira títulos em português">';
+	$html .= '          <textarea required id="orbita_post_title" name="orbita_post_title" value="' . $get_t . '" placeholder="Prefira títulos em português" rows="1" onkeyup="const charactersPerLine = this.offsetWidth / 10;this.rows = Math.round(this.value.length / charactersPerLine) + 1;" />';
 	$html .= '      </div>';
 	$html .= '      <div class="orbita-form-control">';
 	$html .= '          <p>Deixe o link vazio para iniciar uma discussão (que pode ser uma dúvida, por exemplo). Se você enviar um comentário ele irá aparecer no topo.</p>';

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -242,6 +242,15 @@ $desktop: "only screen and (min-width : 700px)";
     display: block;
     font-size: 0.75rem;
   }
+
+  #orbita_post_title {
+    resize: none;
+    width: 100%;
+
+    @media #{$desktop} {
+      width: 50%;
+    }
+  }
 }
 
 .orbita-bookmarklet {


### PR DESCRIPTION
Usei o evento `onkeyup` pra alterar as `rows` da textarea de acordo com o tanto de texto dentro dela. Tentei pegar uma média de caracteres por linha baseado na largura do campo (ou seja, vai funcionar no desktop também), não é 100% mas acredito que o funcionamento esteja bem bom.