### PR TITLE
Shortcode de CSS e JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,6 @@ grunt compress
 
 ## Shortcodes
 
-`[orbita-css]`: carrega arquivo CSS
-
-`[orbita-js]`: carrega arquivo JavaScript
-
 `[orbita-form]`: formulário de postagem
 
 `[orbita-ranking]`: ranking com posts mais votados

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # 🪐 Órbita
 
-Plugin de Wordpress para criar um painel de debates baseado em links, similar ao Hacker News, para o [Manual do Usuário](https://manualdousuario.net).
+Plugin de WordPress para criar um painel de debates baseado em links, similar ao Hacker News, para o [Manual do Usuário](https://manualdousuario.net).
 
 ## Rodar o projeto
 
 Requisitos
 - Node.js
 - Grunt
-- [Child theme do MdU](https://github.com/rghedin/ten-years)
 
 Clone o repositório
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ Gerar arquivo `orbita.zip`
 grunt compress
 ```
 
+## Shortcodes
+
+`[orbita-css]`: carrega arquivo CSS
+
+`[orbita-js]`: carrega arquivo JavaScript
+
+`[orbita-form]`: formulário de postagem
+
+`[orbita-ranking]`: ranking com posts mais votados
+
+`[orbita-posts]`: listagem de post
+
+`[orbita-header]`: menu
+
+`[orbita-vote]`: componente de votoção
+
 ## Instalar o plugin
 
 1. Faça login no seu admin do WordPress

--- a/orbita.php
+++ b/orbita.php
@@ -56,10 +56,14 @@ add_action( 'wp_enqueue_scripts', 'orbita_enqueue_styles' );
  */
 function orbita_enqueue_scripts() {
 	wp_register_script( 'orbita', plugins_url( '/public/main.min.js', __FILE__ ), array(), ORBITA_VERSION, true );
-	wp_localize_script( 'orbita', 'orbitaApi', array(
-		'restURL' => rest_url(),
-		'restNonce' => wp_create_nonce('wp_rest')
-	));
+	wp_localize_script(
+		'orbita',
+		'orbitaApi',
+		array(
+			'restURL'   => rest_url(),
+			'restNonce' => wp_create_nonce( 'wp_rest' ),
+		)
+	);
 }
 
 add_action( 'wp_enqueue_scripts', 'orbita_enqueue_scripts' );
@@ -142,7 +146,7 @@ function orbita_get_vote_html( $post_id ) {
 	$users_vote_array = get_post_meta( $post_id, $users_vote_key, true );
 	$already_voted    = false;
 	$additional_class = '';
-	$title = "Votar";
+	$title            = 'Votar';
 
 	if ( $users_vote_array && array_search( get_current_user_id(), $users_vote_array, true ) !== false ) {
 		$already_voted = true;
@@ -152,7 +156,7 @@ function orbita_get_vote_html( $post_id ) {
 	}
 	if ( $already_voted ) {
 		$additional_class = 'orbita-vote-already-voted';
-		$title = "Você já votou!";
+		$title            = 'Você já votou!';
 	}
 
 	$html  = '<button title="' . $title . '" class="orbita-vote ' . $additional_class . '" data-post-id="' . $post_id . '">⬆️';
@@ -195,7 +199,7 @@ function orbita_get_post_html( $post_id ) {
 		$external_url = get_permalink();
 	}
 	$regex       = '/manualdousuario.net\/orbita/i';
-	$only_domain = preg_match( $regex, $external_url ) ? 'debate' : wp_parse_url( str_replace('www.', '', $external_url), PHP_URL_HOST );
+	$only_domain = preg_match( $regex, $external_url ) ? 'debate' : wp_parse_url( str_replace( 'www.', '', $external_url ), PHP_URL_HOST );
 	$count_key   = 'post_like_count';
 	$count       = get_post_meta( $post_id, $count_key, true );
 
@@ -204,9 +208,9 @@ function orbita_get_post_html( $post_id ) {
 	}
 
 	wp_timezone_string( 'America/Sao_Paulo' );
-	$human_date = human_time_diff(get_the_time('U'), current_time( 'timestamp' ));
+	$human_date = human_time_diff( get_the_time( 'U' ), current_time( 'timestamp' ) );
 
-	$votes_text = ($count > 1 && $count != 'nenhum') ? 'votos' : 'voto';
+	$votes_text = ( $count > 1 && 'nenhum' !== $count ) ? 'votos' : 'voto';
 
 	$html  = '<article class="orbita-post">';
 	$html .= orbita_get_vote_html( $post_id );
@@ -636,9 +640,16 @@ function orbita_update_post_likes() {
 	die();
 }
 
-add_action('rest_api_init', function() {
-	register_rest_route('orbitaApi/v1', '/likes/', array(
-		'methods' => 'POST',
-		'callback' => 'orbita_update_post_likes'
-	));
-});
+add_action(
+	'rest_api_init',
+	function() {
+		register_rest_route(
+			'orbitaApi/v1',
+			'/likes/',
+			array(
+				'methods'  => 'POST',
+				'callback' => 'orbita_update_post_likes',
+			)
+		);
+	}
+);

--- a/orbita.php
+++ b/orbita.php
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Define plugin version constant
  */
-define( 'ORBITA_VERSION', '1.1.0' );
+define( 'ORBITA_VERSION', '1.1.1' );
 
 /**
  * Enqueue style file

--- a/orbita.php
+++ b/orbita.php
@@ -169,6 +169,9 @@ function orbita_get_vote_html( $post_id ) {
  * Get Header
  */
 function orbita_get_header_html() {
+	wp_enqueue_style( 'orbita' );
+	wp_enqueue_script( 'orbita' );
+
 	$html  = '<div class="orbita-header">';
 	$html .= '  <a href="/orbita/postar/" class="orbita-post-button">Postar</a>';
 	$html .= '  <div>';
@@ -528,20 +531,6 @@ function orbita_vote_shortcode() {
 }
 
 /**
- * Load CSS file
- */
-function orbita_css_shortcode() {
-	wp_enqueue_style( 'orbita' );
-}
-
-/**
- * Load JavaScript file
- */
-function orbita_js_shortcode() {
-	wp_enqueue_script( 'orbita' );
-}
-
-/**
  * Shortcodes Init
  */
 function orbita_shortcodes_init() {
@@ -550,8 +539,6 @@ function orbita_shortcodes_init() {
 	add_shortcode( 'orbita-posts', 'orbita_posts_shortcode' );
 	add_shortcode( 'orbita-header', 'orbita_header_shortcode' );
 	add_shortcode( 'orbita-vote', 'orbita_vote_shortcode' );
-	add_shortcode( 'orbita-css', 'orbita_css_shortcode' );
-	add_shortcode( 'orbita-js', 'orbita_js_shortcode' );
 }
 
 add_action( 'init', 'orbita_shortcodes_init' );

--- a/orbita.php
+++ b/orbita.php
@@ -528,10 +528,16 @@ function orbita_vote_shortcode() {
 }
 
 /**
- * Load assets
+ * Load CSS file
  */
-function orbita_assets_shortcode() {
+function orbita_css_shortcode() {
 	wp_enqueue_style( 'orbita' );
+}
+
+/**
+ * Load JavaScript file
+ */
+function orbita_js_shortcode() {
 	wp_enqueue_script( 'orbita' );
 }
 
@@ -544,7 +550,8 @@ function orbita_shortcodes_init() {
 	add_shortcode( 'orbita-posts', 'orbita_posts_shortcode' );
 	add_shortcode( 'orbita-header', 'orbita_header_shortcode' );
 	add_shortcode( 'orbita-vote', 'orbita_vote_shortcode' );
-	add_shortcode( 'orbita-assets', 'orbita_assets_shortcode' );
+	add_shortcode( 'orbita-css', 'orbita_css_shortcode' );
+	add_shortcode( 'orbita-js', 'orbita_js_shortcode' );
 }
 
 add_action( 'init', 'orbita_shortcodes_init' );

--- a/orbita.php
+++ b/orbita.php
@@ -166,12 +166,9 @@ function orbita_get_vote_html( $post_id ) {
 }
 
 /**
- * Get Header and load assets
+ * Get Header
  */
 function orbita_get_header_html() {
-	wp_enqueue_style( 'orbita' );
-	wp_enqueue_script( 'orbita' );
-
 	$html  = '<div class="orbita-header">';
 	$html .= '  <a href="/orbita/postar/" class="orbita-post-button">Postar</a>';
 	$html .= '  <div>';
@@ -531,6 +528,14 @@ function orbita_vote_shortcode() {
 }
 
 /**
+ * Load assets
+ */
+function orbita_assets_shortcode() {
+	wp_enqueue_style( 'orbita' );
+	wp_enqueue_script( 'orbita' );
+}
+
+/**
  * Shortcodes Init
  */
 function orbita_shortcodes_init() {
@@ -539,6 +544,7 @@ function orbita_shortcodes_init() {
 	add_shortcode( 'orbita-posts', 'orbita_posts_shortcode' );
 	add_shortcode( 'orbita-header', 'orbita_header_shortcode' );
 	add_shortcode( 'orbita-vote', 'orbita_vote_shortcode' );
+	add_shortcode( 'orbita-assets', 'orbita_assets_shortcode' );
 }
 
 add_action( 'init', 'orbita_shortcodes_init' );
@@ -640,6 +646,9 @@ function orbita_update_post_likes() {
 	die();
 }
 
+/**
+ * REST API
+ */
 add_action(
 	'rest_api_init',
 	function() {

--- a/orbita.php
+++ b/orbita.php
@@ -38,10 +38,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Define plugin version constant
+ */
+define( 'ORBITA_VERSION', '1.0.4' );
+
+/**
  * Enqueue style file
  */
 function orbita_enqueue_styles() {
-	wp_enqueue_style( 'orbita', plugins_url( '/public/main.css', __FILE__ ), array(), '1', false );
+	wp_register_style( 'orbita', plugins_url( '/public/main.css', __FILE__ ), array(), ORBITA_VERSION, 'all' );
 }
 
 add_action( 'wp_enqueue_scripts', 'orbita_enqueue_styles' );
@@ -50,7 +55,7 @@ add_action( 'wp_enqueue_scripts', 'orbita_enqueue_styles' );
  * Enqueue script file
  */
 function orbita_enqueue_scripts() {
-	wp_enqueue_script( 'orbita', plugins_url( '/public/main.min.js', __FILE__ ), array(), '1', false );
+	wp_register_script( 'orbita', plugins_url( '/public/main.min.js', __FILE__ ), array(), ORBITA_VERSION, true );
 	wp_localize_script( 'orbita', 'orbitaApi', array(
 		'restURL' => rest_url(),
 		'restNonce' => wp_create_nonce('wp_rest')
@@ -157,9 +162,12 @@ function orbita_get_vote_html( $post_id ) {
 }
 
 /**
- * Get Header
+ * Get Header and load assets
  */
 function orbita_get_header_html() {
+	wp_enqueue_style( 'orbita' );
+	wp_enqueue_script( 'orbita' );
+
 	$html  = '<div class="orbita-header">';
 	$html .= '  <a href="/orbita/postar/" class="orbita-post-button">Postar</a>';
 	$html .= '  <div>';
@@ -295,7 +303,7 @@ function orbita_ranking_shortcode( $atts = array(), $content = null, $tag = '' )
 	);
 
 	$orbita_posts_array = orbita_ranking_calculator(
-		$args_orbita, 
+		$args_orbita,
 		$orbita_rank_atts['comment-points'],
 		$orbita_rank_atts['vote-points']
 	);
@@ -310,10 +318,10 @@ function orbita_ranking_shortcode( $atts = array(), $content = null, $tag = '' )
 		),
 	);
 
-	$blog_posts_array = orbita_ranking_calculator( 
-		$args_blog, 
-		$orbita_rank_atts['comment-points'], 
-		$orbita_rank_atts['vote-points'] 
+	$blog_posts_array = orbita_ranking_calculator(
+		$args_blog,
+		$orbita_rank_atts['comment-points'],
+		$orbita_rank_atts['vote-points']
 	);
 
 	$posts_array = array_merge( $orbita_posts_array, $blog_posts_array );
@@ -601,7 +609,7 @@ function orbita_update_post_likes() {
 	if ( ! get_current_user_id() ) {
 		return;
 	}
-	
+
 	if ( ! $_POST ) {
 		return;
 	}

--- a/orbita.php
+++ b/orbita.php
@@ -11,7 +11,7 @@
  * Plugin Name:     Órbita
  * Plugin URI:      https://gnun.es
  * Description:     Órbita é o plugin para criar um sistema Hacker News-like para o Manual do Usuário
- * Version:         1.0.4
+ * Version:         1.1.0
  * Author:          Gabriel Nunes
  * Author URI:      https://gnun.es
  * License:         GPL v3
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Define plugin version constant
  */
-define( 'ORBITA_VERSION', '1.0.4' );
+define( 'ORBITA_VERSION', '1.1.0' );
 
 /**
  * Enqueue style file

--- a/orbita.php
+++ b/orbita.php
@@ -11,7 +11,7 @@
  * Plugin Name:     Órbita
  * Plugin URI:      https://gnun.es
  * Description:     Órbita é o plugin para criar um sistema Hacker News-like para o Manual do Usuário
- * Version:         1.1.0
+ * Version:         1.1.1
  * Author:          Gabriel Nunes
  * Author URI:      https://gnun.es
  * License:         GPL v3

--- a/single-orbita.php
+++ b/single-orbita.php
@@ -8,12 +8,6 @@
  * @license           GPL-3.0
  **/
 
-/**
- * Assets
- */
-echo do_shortcode( '[orbita-css]' );
-echo do_shortcode( '[orbita-js]' );
-
 get_header();
 ?>
 
@@ -41,6 +35,8 @@ get_header();
 
 				wp_timezone_string( 'America/Sao_Paulo' );
 				$date = get_the_date( 'd/m/Y H:i' );
+
+				echo do_shortcode( '[orbita-header]' );
 
 				if ( $external_url ) :
 					the_title( '<h1 class="entry-title">🔗 <a href="' . esc_url( $external_url ) . '" rel="ugc">', '</a></h1>' );

--- a/single-orbita.php
+++ b/single-orbita.php
@@ -8,6 +8,12 @@
  * @license           GPL-3.0
  **/
 
+/**
+ * Assets
+ */
+echo do_shortcode( '[orbita-css]' );
+echo do_shortcode( '[orbita-js]' );
+
 get_header();
 ?>
 


### PR DESCRIPTION
Issue: #12 

- Criei shortcodes para que os assets sejam carregados somente quando necessário.
- Atualizei o readme com os shortcodes disponíveis
- Atualizei o código para o padrão do WP
- Atualizei a versão (fiquei em dúvida entre 1.0.6 ou 1.1.0)

Separar css e js foi uma boa ou era melhor manter um shortcode para os dois?

PS: pode ignorar o commit `carrega assets somente com header`, era apenas teste.