### PR TITLE
Altera links dos comentários para o topo do post

### DIFF
--- a/orbita.php
+++ b/orbita.php
@@ -223,7 +223,7 @@ function orbita_get_post_html( $post_id ) {
 	$html .= '              <span class="orbita-post-domain">' . $only_domain . '</span>';
 	$html .= '          </div>';
 	$html .= '          <div class="orbita-post-date">';
-	$html .= '              <span data-votes-post-id="' . esc_attr( $post_id ) . '">' . $count . ' </span> ' . $votes_text . ' | por ' . get_the_author_meta( 'display_name', $orbita_post->post_author ) . ' ' . $human_date . ' atrás | <a href=" ' . get_permalink() . '#comments">' . get_comments_number_text( 'sem comentários', '1 comentário', '% comentários' ) . '</a>';
+	$html .= '              <span data-votes-post-id="' . esc_attr( $post_id ) . '">' . $count . ' </span> ' . $votes_text . ' | por ' . get_the_author_meta( 'display_name', $orbita_post->post_author ) . ' ' . $human_date . ' atrás | <a href=" ' . get_permalink() . '">' . get_comments_number_text( 'sem comentários', '1 comentário', '% comentários' ) . '</a>';
 	$html .= '          </div>';
 	$html .= '      </div>';
 	$html .= '</div>';


### PR DESCRIPTION
Antes, os links dos comentários embaixo de cada post na capa (`12 comentários`, por exemplo) levava o usuário ao post com a âncora `#comments`. Problema: no **Manual**, pelo menos, essa âncora leva o leitor ao formulário de comentário, ou seja, ele ficava meio perdido lá.

Como o título da listagem de comentários não tem âncora (`id`), removi o `#comments` para que o link abra no início da página do post mesmo. Melhor assim, acho.