### PR TITLE
Muda exibição de índices para listas e melhorias visuais

### DIFF
--- a/orbita.php
+++ b/orbita.php
@@ -11,7 +11,7 @@
  * Plugin Name:     Órbita
  * Plugin URI:      https://gnun.es
  * Description:     Órbita é o plugin para criar um sistema Hacker News-like para o Manual do Usuário
- * Version:         1.1.5
+ * Version:         1.1.6
  * Author:          Gabriel Nunes
  * Author URI:      https://gnun.es
  * License:         GPL v3
@@ -202,7 +202,7 @@ function orbita_get_post_html( $post_id ) {
 		$external_url = get_permalink();
 	}
 	$regex       = '/manualdousuario.net\/orbita/i';
-	$only_domain = preg_match( $regex, $external_url ) ? 'conversa' : wp_parse_url( str_replace( 'www.', '', $external_url ), PHP_URL_HOST );
+	$only_domain = preg_match( $regex, $external_url ) ? '💬' : wp_parse_url( str_replace( 'www.', '', $external_url ), PHP_URL_HOST );
 	$count_key   = 'post_like_count';
 	$count       = get_post_meta( $post_id, $count_key, true );
 
@@ -215,20 +215,16 @@ function orbita_get_post_html( $post_id ) {
 
 	$votes_text = ( $count > 1 && 'nenhum' !== $count ) ? 'votos' : 'voto';
 
-	$html  = '<article class="orbita-post">';
+	$html  = '<li class="orbita-post">';
 	$html .= orbita_get_vote_html( $post_id );
-	$html .= '  <div class="orbita-post-infos">';
-	$html .= '    <div class="orbita-post-title">';
 	$html .= '          <a href="' . esc_url( $external_url ) . '?utm_source=ManualdoUsuarioNet&utm_medium=Orbita" rel="ugc" title="' . get_the_title() . '">' . get_the_title() . '</a>';
-	$html .= '          <div class="orbita-post-info">';
+	$html .= '          <span class="orbita-post-info">';
 	$html .= '              <span class="orbita-post-domain">' . $only_domain . '</span>';
-	$html .= '          </div>';
-	$html .= '          <div class="orbita-post-date">';
-	$html .= '              <span data-votes-post-id="' . esc_attr( $post_id ) . '">' . $count . ' </span> ' . $votes_text . ' | por ' . get_the_author_meta( 'display_name', $orbita_post->post_author ) . ' ' . $human_date . ' atrás | <a href=" ' . get_permalink() . '">' . get_comments_number_text( 'sem comentários', '1 comentário', '% comentários' ) . '</a>';
-	$html .= '          </div>';
-	$html .= '      </div>';
-	$html .= '</div>';
-	$html .= '</article>';
+	$html .= '          </span><br>';
+	$html .= '          <span class="orbita-post-date">';
+	$html .= '              <span data-votes-post-id="' . esc_attr( $post_id ) . '">' . $count . ' </span> ' . $votes_text . ' / por ' . get_the_author_meta( 'display_name', $orbita_post->post_author ) . ' há ' . $human_date . ' / <a href=" ' . get_permalink() . '">' . get_comments_number_text( 'sem comentários', '1 comentário', '% comentários' ) . '</a>';
+	$html .= '</span>';
+	$html .= '</li>';
 
 	return $html;
 }
@@ -337,14 +333,14 @@ function orbita_ranking_shortcode( $atts = array(), $content = null, $tag = '' )
 	$posts_array = array_slice( $posts_array, 0, 30 );
 
 	$html = '<div class="orbita-ranking">';
-
 	$html .= orbita_get_header_html();
+	$html .= '<ol>';
 
 	foreach ( $posts_array as $post ) {
 		$html .= orbita_get_post_html( $post['id'] );
 	}
 
-	$html .= '</div>';
+	$html .= '</ol>';
 
 	wp_reset_query();
 
@@ -373,7 +369,7 @@ function orbita_posts_shortcode( $atts = array(), $content = null, $tag = '' ) {
 
 	$args = array(
 		'post_type'      => 'orbita_post',
-		'posts_per_page' => 30,
+		'posts_per_page' => 10,
 		'paged'          => $paged,
 	);
 
@@ -386,18 +382,22 @@ function orbita_posts_shortcode( $atts = array(), $content = null, $tag = '' ) {
 	$query = new WP_Query( $args );
 
 	if ( $query->have_posts() ) :
+		$html .= '<ul style="list-style: none; margin-left: 0">';
+
 		while ( $query->have_posts() ) :
 			$query->the_post();
 			$html .= orbita_get_post_html( get_the_id() );
 		endwhile;
 
+		$html .= '</ul>';
+
 		$paged = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
 
-		$html .= get_previous_posts_link( '&laquo; mais recentes' );
-		if ( $paged > 1 ) {
-			$html .= '&nbsp;&nbsp;';
-		}
-		$html .= get_next_posts_link( 'mais antigos &raquo;', $query->max_num_pages );
+		$html .= '<nav class="navigation posts-navigation orbita-navigation" aria-label="Posts"><div class="nav-links">';
+		$html .= '<h2 class="screen-reader-text">Navegação por posts</h2>';
+		$html .= '<div class="nav-previous">'. get_previous_posts_link( '&laquo; Tópicos mais recentes' ) .'</div>';
+		$html .= '<div class="nav-next">'. get_next_posts_link( 'Tópicos mais antigos &raquo;', $query->max_num_pages ) .'</div>';
+		$html .= '</div></nav>';
 	endif;
 
 	wp_reset_query();

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1,78 +1,38 @@
-$desktop: "only screen and (min-width : 700px)";
-
-.orbita_post-template-default {
-  .post-navigation {
-    display: none;
-  }
+.orbita_post-template-default .post-navigation {
+  display: none;
 }
 
-.orbita_post {
-  .orbita-meta {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
+.orbita_post .orbita-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .orbita-post {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-  margin-bottom: .8rem;
-  padding-bottom: 1rem;
+  margin: 0 0 1.5rem;
+  line-height: 1.2;
   border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-
-  @media #{$desktop} {
+}
+@media only screen and (min-width: 700px) {
+  .orbita-post {
     padding-bottom: 0;
     border-bottom: 0;
   }
-
-  &-info {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  &-tag {
-    font-size: 21px;
-    display: inline-block;
-    padding: 0 21px;
-    border-radius: var(--borda-curva);
-  }
-
-  &-domain {
-    font-size: var(--small);
-    color: var(--border-color);
-  }
-
-  &-date {
-    font-size: var(--small);
-    font-family: monospace;
-
-    .orbita-report-link {
-      background-color: transparent;
-      border: 0;
-      padding: 0;
-      color: var(--color-primary);
-      text-decoration: underline;
-      font-size: var(--small);
-      float: none;
-      text-transform: lowercase;
-      cursor: pointer;
-    }
-  }
 }
 
-.orbita-ranking {
-  counter-increment: css-counter 0;
-
-  .orbita-post {
-    counter-increment: css-counter 1;
-
-    &:before {
-      content: counter(css-counter) ". ";
-    }
-  }
+.orbita-post-tag {
+  font-size: 21px;
+  display: inline-block;
+  padding: 0 21px;
+  border-radius: var(--borda-curva);
+}
+.orbita-post-domain {
+  font-size: var(--small);
+  color: #a6a6a6;
+}
+.orbita-post-date {
+  font-family: monospace;
+  font-size: 95%;
 }
 
 .orbita-header {
@@ -86,53 +46,57 @@ $desktop: "only screen and (min-width : 700px)";
   align-items: center;
   font-family: -apple-system, sans-serif;
   line-height: 2;
-
-  div a {
-    margin: 0 .3rem;
-    display: inline;
-
-    &:visited {
-      color: var(--color-link);
-    }
-
-    &:hover {
-      color: var(--color-link-states);
-    }
-
-    @media #{$desktop} {
-      margin: 0 0 0 1rem;
-    }
+}
+.orbita-header div a {
+  margin: 0 .3rem;
+  display: inline;
+}
+.orbita-header div a:visited {
+  color: var(--color-link);
+}
+.orbita-header div a:hover {
+  color: var(--color-link-states);
+}
+@media only screen and (min-width: 700px) {
+  .orbita-header div a {
+    margin: 0 0 0 1rem;
   }
-
-  @media #{$desktop} {
+}
+@media only screen and (min-width: 700px) {
+  .orbita-header {
     flex-direction: row;
     max-width: 100%;
     line-height: inherit;
     padding: 0.5rem 1rem;
   }
-
-  .orbita-post-button {
-    @media #{$desktop} {
-      margin-right: auto;
-    }
+}
+@media only screen and (min-width: 700px) {
+  .orbita-header .orbita-post-button {
+    margin-right: auto;
   }
+}
+
+.orbita-ranking ol {
+  list-style: none;
+  margin-left: 0;
 }
 
 .orbita-vote {
   border: 0;
   padding: 0;
   position: relative;
+  left: -2px;
   cursor: default;
   background: transparent !important;
-
-  &-can-vote {
-    cursor: pointer;
-  }
-
-  &-already-voted {
-    cursor: default !important;
-    opacity: 0.5;
-  }
+  font-size: 90%;
+  filter: grayscale();
+}
+.orbita-vote-can-vote {
+  cursor: pointer;
+}
+.orbita-vote-already-voted {
+  cursor: default !important;
+  opacity: 0.4;
 }
 
 .orbita-form {
@@ -141,71 +105,60 @@ $desktop: "only screen and (min-width : 700px)";
 
 .orbita-form-control {
   margin-bottom: 0.5rem;
-
-  label {
-    display: block;
-    cursor: pointer;
+}
+.orbita-form-control label {
+  display: block;
+  cursor: pointer;
+}
+.orbita-form-control input[type="text"],
+.orbita-form-control input[type="url"] {
+  width: 100%;
+}
+@media only screen and (min-width: 700px) {
+  .orbita-form-control input[type="text"],
+  .orbita-form-control input[type="url"] {
+    width: 50%;
   }
-
-  input[type="text"],
-  input[type="url"] {
-    width: 100%;
-
-    @media #{$desktop} {
-      width: 50%;
-    }
-  }
-
-  input[type="url"] {
-    background-color: var(--light-bg);
-    color: var(--txt-color);
-    border: 1px solid var(--border-color);
-  }
-
-  textarea {
-    max-width: 60ch;
-    background-color: var(--light-bg);
-  }
-
-  .orbita-help-block {
-    font-family: monospace;
-    display: block;
-    font-size: var(--small);
-  }
-
-  .orbita-post-title {
-    line-height: 1.2;
-  }
-
-  .orbita-post-title-textarea {
-    resize: none;
-    width: 100%;
-  }
+}
+.orbita-form-control input[type="url"] {
+  background-color: var(--light-bg);
+  color: var(--txt-color);
+  border: 1px solid var(--border-color);
+}
+.orbita-form-control textarea {
+  max-width: 60ch;
+  background-color: var(--light-bg);
+}
+.orbita-form-control .orbita-help-block {
+  font-family: monospace;
+  display: block;
+  font-size: var(--small);
+}
+.orbita-form-control .orbita-post-title {
+  line-height: 1.2;
+}
+.orbita-form-control .orbita-post-title-textarea {
+  resize: none;
+  width: 100%;
 }
 
 .orbita-bookmarklet {
   padding: 24px;
   margin-top: 32px;
   display: none;
-
-  @media #{$desktop} {
+}
+@media only screen and (min-width: 700px) {
+  .orbita-bookmarklet {
     display: block;
   }
 }
 
-.orbita-report-link {
-  float: right;
-  cursor: pointer;
-
-  &-already-reported {
-    background: transparent;
-    border: 0;
-    text-decoration: none;
-    color: var(--color-primary);
-    cursor: default !important;
-  }
+.orbita-navigation {
+  margin-top: 6rem !important;
 }
 
 .orbita-footer {
   float: right;
 }
+
+/*# sourceMappingURL=main.css.map */


### PR DESCRIPTION
Notei que o índice de posts era feito usando tags `<article>`. Alterei para listas simples. Aproveitei para dar uma mexidinha na apresentação e colocar os controles de paginação da página `/tudo` no padrão do Manual/WordPress, usando a tag `<nav>`.