### PR TITLE
Redirecionamento para post apos publicação

### DIFF
--- a/orbita.php
+++ b/orbita.php
@@ -433,8 +433,9 @@ function orbita_form_shortcode() {
 		return $html;
 	}
 
-	$orbita_error = $_REQUEST['orbita_error'];
-	if ( isset($orbita_error) ) {
+	if ( isset($_REQUEST['orbita_error']) ) {
+		$orbita_error = $_REQUEST['orbita_error'];
+
 		if( $orbita_error == 'duplicated' ) {
 			$orbita_post_id = $_REQUEST['orbita_post_id'];
 

--- a/orbita.php
+++ b/orbita.php
@@ -433,15 +433,18 @@ function orbita_form_shortcode() {
 		return $html;
 	}
 
-	if ( isset($_REQUEST['orbita_error']) ) {
-		if($_REQUEST['orbita_error'] == 'duplicated') {
-			if(isset($_REQUEST['orbita_post_id'])) {
-				$html = 'Parece que este post <a href="' . get_permalink($_REQUEST['orbita_post_id']) . '">já existe</a>.';
+	$orbita_error = $_REQUEST['orbita_error'];
+	if ( isset($orbita_error) ) {
+		if( $orbita_error == 'duplicated' ) {
+			$orbita_post_id = $_REQUEST['orbita_post_id'];
+
+			if( isset($orbita_post_id) ) {
+				$html = 'Parece que este post <a href="' . get_permalink($orbita_post_id) . '">já existe</a>.';
 			} else {
 				$html = 'Parece que este post já existe.';
 			}
 		}
-		if($_REQUEST['orbita_error'] == 'user_logged') {
+		if( $orbita_error == 'user_logged' ) {
 			$html = 'Para postar links ou iniciar conversas na Órbita, <a href="' . wp_login_url( home_url( '/orbita/postar' ) ) . '">faça login</a> ou <a href="' . wp_registration_url() . '">cadastre-se gratuitamente</a>.';
 		}
 		return $html;


### PR DESCRIPTION
Issue: https://github.com/gabrnunes/orbita/issues/15

### Checklist
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 14 (` * Version:         1.x.x`)
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 43 (`define( 'ORBITA_VERSION', '1.x.x' );`)

### Descrição

- Atualizei para a versão `1.2` por ser uma funcionalidade nova
- O `$_POST` está sendo capturado dentro de `wp_loaded`, conforme documentação do Wordpress é um caminho melhor que `template_redirect` por atingir antes dos primeiros headers e fazer o redirecionamento correto
- A função [get_page_by_title()](https://make.wordpress.org/core/2023/03/06/get_page_by_title-deprecated/) foi deprecada, alterei para um `WP_Query` que busca um post com mesmo nome e autor
- Utilizei o padrão `orbita_error` e `orbita_post_id` nas variáveis `$_GET` para não misturar com qualquer outra funcionalidade, normalmente pode registrar variaveis no wordpress, por questões de permalinks, mas no caso de erro o `$_REQUEST` me pareceu suficiente

É importante testar bastante, validar inclusive dentro do Admin (devido ao `wp_loaded`) ao editar e salvar se tudo está seguindo o caminho correto